### PR TITLE
[GYJB-132] Category 삭제 API 구현

### DIFF
--- a/src/main/java/com/linklip/linklipserver/constant/SuccessResponse.java
+++ b/src/main/java/com/linklip/linklipserver/constant/SuccessResponse.java
@@ -9,7 +9,8 @@ public enum SuccessResponse {
     CREATE_CATEGORY_SUCCESS(HttpStatus.CREATED, "OK3", "카테고리 생성 완료"),
     GET_CATEGORY_SUCCESS(HttpStatus.OK, "OK4", "카테고리 조회 완료"),
     UPDATE_CATEGORY_SUCCESS(HttpStatus.OK, "OK5", "카테고리 수정 완료"),
-    UPDATE_LINK_SUCCESS(HttpStatus.OK, "OK6", "링크 수정 완료");
+    UPDATE_LINK_SUCCESS(HttpStatus.OK, "OK6", "링크 수정 완료"),
+    DELETE_CATEGORY_SUCCESS(HttpStatus.OK, "OK7", "카테고리 삭제 완료");
 
     @Getter private int status;
 

--- a/src/main/java/com/linklip/linklipserver/controller/CategoryController.java
+++ b/src/main/java/com/linklip/linklipserver/controller/CategoryController.java
@@ -83,7 +83,7 @@ public class CategoryController {
     @ResponseBody
     public ResponseEntity<?> deleteCategoryV1(@PathVariable Long categoryId) {
 
-        categoryService.deleteCategory(categoryId);
+        categoryService.releaseCategory(categoryId);
 
         return new ResponseEntity<>(
                 new ServerResponse(

--- a/src/main/java/com/linklip/linklipserver/controller/CategoryController.java
+++ b/src/main/java/com/linklip/linklipserver/controller/CategoryController.java
@@ -76,4 +76,20 @@ public class CategoryController {
                         UPDATE_CATEGORY_SUCCESS.getMessage()),
                 HttpStatus.OK);
     }
+
+    @ApiOperation(value = "카테고리 삭제 API v1")
+    @ApiResponses({@ApiResponse(code = 200, message = "카테고리 삭제 완료")})
+    @DeleteMapping("/v1/{categoryId}")
+    @ResponseBody
+    public ResponseEntity<?> deleteCategoryV1(@PathVariable Long categoryId) {
+
+        categoryService.deleteCategory(categoryId);
+
+        return new ResponseEntity<>(
+                new ServerResponse(
+                        DELETE_CATEGORY_SUCCESS.getStatus(),
+                        DELETE_CATEGORY_SUCCESS.getSuccess(),
+                        DELETE_CATEGORY_SUCCESS.getMessage()),
+                HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/linklip/linklipserver/repository/ContentRepository.java
+++ b/src/main/java/com/linklip/linklipserver/repository/ContentRepository.java
@@ -4,6 +4,7 @@ import com.linklip.linklipserver.domain.Content;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,4 +20,8 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
 
     @Query("SELECT c FROM Content c WHERE c.title LIKE %:term% OR c.text LIKE %:term%")
     Page<Content> findByTerm(@Param("term") String term, Pageable pageable);
+
+    @Modifying(clearAutomatically = true) // executeUpdate 같은 Annotation
+    @Query("UPDATE Content c SET c.category = null WHERE c.category.id = :categoryId")
+    void deleteByCategoryId(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/linklip/linklipserver/repository/ContentRepository.java
+++ b/src/main/java/com/linklip/linklipserver/repository/ContentRepository.java
@@ -23,5 +23,5 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
 
     @Modifying(clearAutomatically = true) // executeUpdate 같은 Annotation
     @Query("UPDATE Content c SET c.category = null WHERE c.category.id = :categoryId")
-    void deleteByCategoryId(@Param("categoryId") Long categoryId);
+    void releaseCategoryByCategoryId(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/linklip/linklipserver/service/CategoryService.java
+++ b/src/main/java/com/linklip/linklipserver/service/CategoryService.java
@@ -4,10 +4,13 @@ import com.linklip.linklipserver.domain.Category;
 import com.linklip.linklipserver.dto.category.CategoryDto;
 import com.linklip.linklipserver.dto.category.CreateCategoryRequest;
 import com.linklip.linklipserver.dto.category.UpdateCategoryRequest;
+import com.linklip.linklipserver.exception.InvalidIdException;
 import com.linklip.linklipserver.repository.CategoryRepository;
+import com.linklip.linklipserver.repository.ContentRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CategoryService {
+    private final ContentRepository contentRepository;
     private final CategoryRepository categoryRepository;
 
     @Transactional
@@ -37,5 +41,15 @@ public class CategoryService {
                         .findById(categoryId)
                         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 categoryId입니다."));
         category.update(request.getName());
+    }
+
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+        contentRepository.deleteByCategoryId(categoryId);
+        try {
+            categoryRepository.deleteById(categoryId);
+        } catch (EmptyResultDataAccessException e) {
+            throw new InvalidIdException("존재하지 않는 categoryId입니다.");
+        }
     }
 }

--- a/src/main/java/com/linklip/linklipserver/service/CategoryService.java
+++ b/src/main/java/com/linklip/linklipserver/service/CategoryService.java
@@ -44,8 +44,8 @@ public class CategoryService {
     }
 
     @Transactional
-    public void deleteCategory(Long categoryId) {
-        contentRepository.deleteByCategoryId(categoryId);
+    public void releaseCategory(Long categoryId) {
+        contentRepository.releaseCategoryByCategoryId(categoryId);
         try {
             categoryRepository.deleteById(categoryId);
         } catch (EmptyResultDataAccessException e) {

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
@@ -192,7 +192,7 @@ public class CategoryIntegrationTest {
             Category category1 = Category.builder().name("운동").build();
             Category category2 = Category.builder().name("개발").build();
             Category savedCategory1 = categoryRepository.save(category1);
-            Category savedCategory2 = categoryRepository.save(category2);
+            categoryRepository.save(category2);
 
             // when
             ResultActions actions =

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
@@ -1,14 +1,19 @@
 package com.linklip.linklipserver.IntegrationtTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linklip.linklipserver.TestUtils;
 import com.linklip.linklipserver.domain.Category;
+import com.linklip.linklipserver.domain.Content;
 import com.linklip.linklipserver.dto.category.CreateCategoryRequest;
 import com.linklip.linklipserver.dto.category.UpdateCategoryRequest;
 import com.linklip.linklipserver.repository.CategoryRepository;
+import com.linklip.linklipserver.repository.ContentRepository;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,9 @@ public class CategoryIntegrationTest {
     @Autowired private MockMvc mockMvc;
 
     @Autowired private CategoryRepository categoryRepository;
+    @Autowired private ContentRepository contentRepository;
+
+    @Autowired private TestUtils testUtils;
 
     @Nested
     @DisplayName("카테고리 생성 통합테스트")
@@ -43,7 +51,7 @@ public class CategoryIntegrationTest {
             mockMvc.perform(
                             post("/category/v1")
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(createCategoryRequest)))
+                                    .content(testUtils.asJsonString(createCategoryRequest)))
                     .andExpect(status().isCreated());
         }
 
@@ -57,7 +65,7 @@ public class CategoryIntegrationTest {
             mockMvc.perform(
                             post("/category/v1")
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(createCategoryRequest)))
+                                    .content(testUtils.asJsonString(createCategoryRequest)))
                     .andExpect(status().isCreated());
         }
 
@@ -70,7 +78,7 @@ public class CategoryIntegrationTest {
             mockMvc.perform(
                             post("/category/v1")
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(createCategoryRequest)))
+                                    .content(testUtils.asJsonString(createCategoryRequest)))
                     .andExpect(status().isBadRequest());
         }
 
@@ -83,7 +91,7 @@ public class CategoryIntegrationTest {
             mockMvc.perform(
                             post("/category/v1")
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(createCategoryRequest)))
+                                    .content(testUtils.asJsonString(createCategoryRequest)))
                     .andExpect(status().isBadRequest());
         }
     }
@@ -119,7 +127,7 @@ public class CategoryIntegrationTest {
                     mockMvc.perform(
                             patch("/category/v1/{categoryId}", categoryId)
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(updateCategoryRequest)));
+                                    .content(testUtils.asJsonString(updateCategoryRequest)));
 
             // then
             actions.andExpect(status().isOk()).andDo(print());
@@ -144,7 +152,7 @@ public class CategoryIntegrationTest {
                     mockMvc.perform(
                             patch("/category/v1/{categoryId}", categoryId)
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(updateCategoryRequest)));
+                                    .content(testUtils.asJsonString(updateCategoryRequest)));
 
             // then
             actions.andExpect(status().isOk());
@@ -167,18 +175,73 @@ public class CategoryIntegrationTest {
                     mockMvc.perform(
                             patch("/category/v1/{categoryId}", categoryId)
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(updateCategoryRequest)));
+                                    .content(testUtils.asJsonString(updateCategoryRequest)));
 
             // then
             actions.andExpect(status().isBadRequest());
         }
     }
 
-    public static String asJsonString(final Object obj) {
-        try {
-            return new ObjectMapper().writeValueAsString(obj);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+    @Nested
+    @DisplayName("카테고리 삭제 통합테스트")
+    class deleteCategoryIntegrationTest {
+        @Test
+        @DisplayName("컨텐츠가 존재하지 않는 카테고리 수정")
+        public void deleteEmptyCategory() throws Exception {
+            // given
+            Category category1 = Category.builder().name("운동").build();
+            Category category2 = Category.builder().name("개발").build();
+            Category savedCategory1 = categoryRepository.save(category1);
+            Category savedCategory2 = categoryRepository.save(category2);
+
+            // when
+            ResultActions actions =
+                    mockMvc.perform(
+                            delete("/category/v1/{categoryId}", savedCategory1.getId())
+                                    .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            actions.andExpect(status().isOk());
+
+            List<Category> all = categoryRepository.findAll();
+            assertThat(all.size()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("컨텐츠가 존재하는 카테고리 수정")
+        public void deleteCategoryHavingContents() throws Exception {
+            // given
+            Category category1 = Category.builder().name("홈페이지").build();
+            Category savedCategory1 = categoryRepository.save(category1);
+            Category category2 = Category.builder().name("개발").build();
+            Category savedCategory2 = categoryRepository.save(category2);
+
+            Content content1 =
+                    testUtils.saveContent("naver.com", "Naver", "뉴스 로그인 회원가입", savedCategory1);
+            Content content2 =
+                    testUtils.saveContent("soma.org", "소프트웨어 마에스트로", "소마 홈페이지", savedCategory1);
+            Content content3 =
+                    testUtils.saveContent("soma.org", "소프트웨어 마에스트로", "소마 홈페이지", savedCategory2);
+
+            // when
+            ResultActions actions =
+                    mockMvc.perform(
+                            delete("/category/v1/{categoryId}", savedCategory1.getId())
+                                    .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            actions.andExpect(status().isOk());
+
+            List<Category> all = categoryRepository.findAll();
+            assertThat(all.size()).isEqualTo(1);
+
+            Optional<Content> findContent1 = contentRepository.findById(content1.getId());
+            Optional<Content> findContent2 = contentRepository.findById(content2.getId());
+            Optional<Content> findContent3 = contentRepository.findById(content3.getId());
+
+            assertThat(findContent1.get().getCategory()).isEqualTo(null);
+            assertThat(findContent2.get().getCategory()).isEqualTo(null);
+            assertThat(findContent3.get().getCategory().getId()).isEqualTo(savedCategory2.getId());
         }
     }
 }

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linklip.linklipserver.TestUtils;
 import com.linklip.linklipserver.domain.Category;
 import com.linklip.linklipserver.domain.Content;
 import com.linklip.linklipserver.dto.content.UpdateLinkRequest;
@@ -33,6 +33,8 @@ public class ContentIntegrationTest {
 
     @Autowired private ContentRepository contentRepository;
     @Autowired private CategoryRepository categoryRepository;
+
+    @Autowired private TestUtils testUtils;
 
     @Nested
     @DisplayName("링크 검색 통합테스트")
@@ -274,7 +276,7 @@ public class ContentIntegrationTest {
                             MockMvcRequestBuilders.patch(
                                             "/content/v1/link/{contentId}", savedContent.getId())
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(updateLinkRequest)));
+                                    .content(testUtils.asJsonString(updateLinkRequest)));
 
             actions.andExpect(status().isOk());
 
@@ -303,7 +305,7 @@ public class ContentIntegrationTest {
                             MockMvcRequestBuilders.patch(
                                             "/content/v1/link/{contentId}", savedContent.getId())
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(updateLinkRequest)));
+                                    .content(testUtils.asJsonString(updateLinkRequest)));
 
             actions.andExpect(status().isOk());
 
@@ -333,17 +335,9 @@ public class ContentIntegrationTest {
                             MockMvcRequestBuilders.patch(
                                             "/content/v1/link/{contentId}", savedContent.getId())
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(asJsonString(updateLinkRequest)));
+                                    .content(testUtils.asJsonString(updateLinkRequest)));
 
             actions.andExpect(status().isBadRequest());
-        }
-    }
-
-    public static String asJsonString(final Object obj) {
-        try {
-            return new ObjectMapper().writeValueAsString(obj);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/com/linklip/linklipserver/TestUtils.java
+++ b/src/test/java/com/linklip/linklipserver/TestUtils.java
@@ -1,0 +1,31 @@
+package com.linklip.linklipserver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linklip.linklipserver.domain.Category;
+import com.linklip.linklipserver.domain.Content;
+import com.linklip.linklipserver.repository.ContentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestUtils {
+
+    @Autowired private ContentRepository contentRepository;
+
+    public Content saveContent(String url, String title, String text, Category category) {
+
+        Content content =
+                Content.builder().linkUrl(url).title(title).text(text).category(category).build();
+        contentRepository.save(content);
+
+        return content;
+    }
+
+    public String asJsonString(final Object obj) {
+        try {
+            return new ObjectMapper().writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/linklip/linklipserver/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/linklip/linklipserver/repository/CategoryRepositoryTest.java
@@ -79,4 +79,25 @@ class CategoryRepositoryTest {
             assertThat(categoryList.get(1)).isEqualTo(category1);
         }
     }
+
+    @Nested
+    @DisplayName("카테고리 삭제 테스트")
+    class deleteCategory {
+        @Test
+        @DisplayName("일반적인 카테고리 삭제")
+        public void deleteCategory() {
+            // given
+            Category category1 = Category.builder().name("채용 정보").build();
+            Category category2 = Category.builder().name("개발 정보").build();
+            categoryRepository.save(category1);
+            categoryRepository.save(category2);
+
+            // when
+            categoryRepository.deleteById(category1.getId());
+
+            // then
+            List<Category> categoryList = categoryRepository.findAllByOrderByName();
+            assertThat(categoryList.size()).isEqualTo(1);
+        }
+    }
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] Set Reviewers

- [x] Set Labels

---

### 📕 Task

- [x] Category 삭제 API 구현
- [x] Category 삭제시 Category에 소속된 컨텐츠의 카테고리 할당 해제 (-> null)

### 😳 Issue

- [ ] Data JPA를 활용한 delete 처리 요청시 Select 쿼리가 한번 더 날아가는데 개선 가능성 확인 필요

<img width="696" alt="Screen Shot 2022-08-17 at 4 04 25 PM" src="https://user-images.githubusercontent.com/39653584/185095921-e4f4c83c-21d6-4bb7-a1ba-e4bbded79d39.png">

