### PR TITLE
[FEAT] 메모(Note) 저장 API 구현

### DIFF
--- a/src/main/java/com/linklip/linklipserver/constant/SuccessResponse.java
+++ b/src/main/java/com/linklip/linklipserver/constant/SuccessResponse.java
@@ -13,6 +13,7 @@ public enum SuccessResponse {
     FIND_CONTENT_SUCCESS(HttpStatus.OK, "OK7", "컨텐츠 상세보기 응답 완료"),
     DELETE_CATEGORY_SUCCESS(HttpStatus.OK, "OK8", "카테고리 삭제 완료"),
     DELETE_CONTENT_SUCCESS(HttpStatus.OK, "OK9", "컨텐츠 삭제 완료"),
+    SAVE_NOTE_SUCCESS(HttpStatus.CREATED, "OK10", "메모 저장 완료"),
     ;
 
     @Getter private final int status;

--- a/src/main/java/com/linklip/linklipserver/controller/ContentController.java
+++ b/src/main/java/com/linklip/linklipserver/controller/ContentController.java
@@ -1,17 +1,10 @@
 package com.linklip.linklipserver.controller;
 
-import static com.linklip.linklipserver.constant.SuccessResponse.DELETE_CONTENT_SUCCESS;
-import static com.linklip.linklipserver.constant.SuccessResponse.FIND_CONTENT_LIST_SUCCESS;
-import static com.linklip.linklipserver.constant.SuccessResponse.FIND_CONTENT_SUCCESS;
-import static com.linklip.linklipserver.constant.SuccessResponse.SAVE_LINK_SUCCESS;
-import static com.linklip.linklipserver.constant.SuccessResponse.UPDATE_LINK_SUCCESS;
+import static com.linklip.linklipserver.constant.SuccessResponse.*;
 
 import com.linklip.linklipserver.dto.ServerResponse;
 import com.linklip.linklipserver.dto.ServerResponseWithData;
-import com.linklip.linklipserver.dto.content.FindContentRequest;
-import com.linklip.linklipserver.dto.content.FindContentResponse;
-import com.linklip.linklipserver.dto.content.SaveLinkRequest;
-import com.linklip.linklipserver.dto.content.UpdateLinkRequest;
+import com.linklip.linklipserver.dto.content.*;
 import com.linklip.linklipserver.service.ContentService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.annotations.*;
@@ -107,5 +100,20 @@ public class ContentController {
                         DELETE_CONTENT_SUCCESS.getSuccess(),
                         DELETE_CONTENT_SUCCESS.getMessage()),
                 HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "메모 저장 API v1")
+    @ApiResponses({@ApiResponse(code = 201, message = "메모 저장 완료")})
+    @PostMapping("/v1/note")
+    public ResponseEntity<?> saveNoteV1(@RequestBody @Valid SaveNoteRequest request) {
+
+        contentService.saveNoteContent(request);
+
+        return new ResponseEntity<>(
+                new ServerResponse(
+                        SAVE_NOTE_SUCCESS.getStatus(),
+                        SAVE_NOTE_SUCCESS.getSuccess(),
+                        SAVE_NOTE_SUCCESS.getMessage()),
+                HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/linklip/linklipserver/domain/Link.java
+++ b/src/main/java/com/linklip/linklipserver/domain/Link.java
@@ -1,6 +1,5 @@
 package com.linklip.linklipserver.domain;
 
-import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Lob;

--- a/src/main/java/com/linklip/linklipserver/domain/Link.java
+++ b/src/main/java/com/linklip/linklipserver/domain/Link.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 @DiscriminatorValue("link")
 public class Link extends Content {
 
-    @Column(nullable = false)
     private String linkUrl;
 
     private String linkImg;

--- a/src/main/java/com/linklip/linklipserver/domain/Note.java
+++ b/src/main/java/com/linklip/linklipserver/domain/Note.java
@@ -1,0 +1,24 @@
+package com.linklip.linklipserver.domain;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("note")
+public class Note extends Content {
+    @Lob // column type을 longtext로 설정
+    private String text;
+
+    @Builder
+    public Note(String text, Category category) {
+        this.text = text;
+        super.updateCategory(category);
+    }
+}

--- a/src/main/java/com/linklip/linklipserver/dto/content/SaveNoteRequest.java
+++ b/src/main/java/com/linklip/linklipserver/dto/content/SaveNoteRequest.java
@@ -1,0 +1,14 @@
+package com.linklip.linklipserver.dto.content;
+
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class SaveNoteRequest {
+    @ApiModelProperty(required = true)
+    @NotEmpty
+    private String text;
+
+    private Long categoryId;
+}

--- a/src/main/java/com/linklip/linklipserver/service/ContentService.java
+++ b/src/main/java/com/linklip/linklipserver/service/ContentService.java
@@ -3,10 +3,8 @@ package com.linklip.linklipserver.service;
 import com.linklip.linklipserver.domain.Category;
 import com.linklip.linklipserver.domain.Content;
 import com.linklip.linklipserver.domain.Link;
-import com.linklip.linklipserver.dto.content.FindContentRequest;
-import com.linklip.linklipserver.dto.content.LinkDto;
-import com.linklip.linklipserver.dto.content.SaveLinkRequest;
-import com.linklip.linklipserver.dto.content.UpdateLinkRequest;
+import com.linklip.linklipserver.domain.Note;
+import com.linklip.linklipserver.dto.content.*;
 import com.linklip.linklipserver.exception.InvalidIdException;
 import com.linklip.linklipserver.repository.CategoryRepository;
 import com.linklip.linklipserver.repository.ContentRepository;
@@ -124,5 +122,19 @@ public class ContentService {
                         .findById(contentId)
                         .orElseThrow(() -> new InvalidIdException("존재하지 않는 contentId입니다"));
         content.delete();
+    }
+
+    public void saveNoteContent(SaveNoteRequest request) {
+        Long categoryId = request.getCategoryId();
+
+        Category category =
+                categoryId == null
+                        ? null
+                        : categoryRepository
+                                .findById(categoryId)
+                                .orElseThrow(() -> new InvalidIdException("존재하지 않는 categoryId입니다"));
+
+        Content content = Note.builder().text(request.getText()).category(category).build();
+        contentRepository.save(content);
     }
 }

--- a/src/test/java/com/linklip/linklipserver/repository/ContentRepositoryTest.java
+++ b/src/test/java/com/linklip/linklipserver/repository/ContentRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.linklip.linklipserver.domain.Category;
 import com.linklip.linklipserver.domain.Content;
 import com.linklip.linklipserver.domain.Link;
+import com.linklip.linklipserver.domain.Note;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -25,7 +26,7 @@ class ContentRepositoryTest {
 
     @Nested
     @DisplayName("링크 저장 테스트")
-    class saveContent {
+    class saveLink {
 
         @Test
         @DisplayName("링크 url만 저장")
@@ -371,6 +372,34 @@ class ContentRepositoryTest {
 
             // then
             assertThat(result.getId()).isEqualTo(content.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("메모 저장 테스트")
+    class saveNoteContent {
+
+        @Test
+        @DisplayName("카테고리 설정 없이 메모 저장")
+        public void saveOnlyText() {
+            Content content = Note.builder().text("TOPCIT 지원 기간 9월 중순까지!!").build();
+
+            Content savedContent = contentRepository.save(content);
+            assertThat(savedContent).isEqualTo(content);
+        }
+
+        @Test
+        @DisplayName("카테고리 설정하여 메모 저장")
+        public void saveTextWithCategory() {
+            Category category = Category.builder().name("시험 접수").build();
+            Category savedCategory = categoryRepository.save(category);
+
+            Content content =
+                    Note.builder().text("TOPCIT 지원 기간 9월 중순까지!!").category(savedCategory).build();
+
+            Content savedContent = contentRepository.save(content);
+            assertThat(savedContent).isEqualTo(content);
+            assertThat(savedContent.getCategory()).isEqualTo(savedCategory);
         }
     }
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] Set Reviewers

- [x] Set Labels

---

### 📕 Task

- [x] Link 엔티티에서 linkUrl nullable 옵션 false로 수정
- [x] Note 엔티티 정의
- [x] saveNote API 구현
- [x] saveNote 관련 단위테스트 작성 완료


