### PR TITLE
[FEAT] GYJB-175 메모 조회 관련 API 구현

### DIFF
--- a/src/main/java/com/linklip/linklipserver/constant/ErrorResponse.java
+++ b/src/main/java/com/linklip/linklipserver/constant/ErrorResponse.java
@@ -5,8 +5,9 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorResponse {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "ERR01", "잘못된 요청입니다"),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "ERR01", "요청 경로 오류"),
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ERR02", "서버 내부 오류");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "ERR02", "요청 경로 오류"),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ERR03", "서버 내부 오류"),
+    INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "ERR04", "잘못된 Content Type입니다");
 
     @Getter private int status;
 

--- a/src/main/java/com/linklip/linklipserver/constant/ErrorResponse.java
+++ b/src/main/java/com/linklip/linklipserver/constant/ErrorResponse.java
@@ -7,7 +7,9 @@ public enum ErrorResponse {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "ERR01", "잘못된 요청입니다"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "ERR02", "요청 경로 오류"),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ERR03", "서버 내부 오류"),
-    INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "ERR04", "잘못된 Content Type입니다");
+    INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "ERR04", "잘못된 Content Type입니다"),
+    NOT_EXSIT_CONTENT_ID(HttpStatus.NOT_FOUND, "ERR05", "존재하지 않는 Content ID입니다"),
+    NOT_EXSIT_CATEGORY_ID(HttpStatus.NOT_FOUND, "ERR06", "존재하지 않는 Category ID입니다");
 
     @Getter private int status;
 

--- a/src/main/java/com/linklip/linklipserver/controller/ContentController.java
+++ b/src/main/java/com/linklip/linklipserver/controller/ContentController.java
@@ -41,10 +41,26 @@ public class ContentController {
                 HttpStatus.CREATED);
     }
 
-    @ApiOperation(value = "컨텐츠 검색 API v1")
+    @ApiOperation(value = "링크 검색 API v1")
     @ApiResponses({@ApiResponse(code = 200, message = "검색결과 조회 완료")})
     @GetMapping("/v1/link")
     public ResponseEntity<?> findContentListV1(
+            @ModelAttribute FindContentRequest request,
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return new ResponseEntity<>(
+                new ServerResponseWithData(
+                        FIND_CONTENT_LIST_SUCCESS.getStatus(),
+                        FIND_CONTENT_LIST_SUCCESS.getSuccess(),
+                        FIND_CONTENT_LIST_SUCCESS.getMessage(),
+                        contentService.findContentList(request, pageable)),
+                HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "컨텐츠 검색 API v1")
+    @ApiResponses({@ApiResponse(code = 200, message = "검색결과 조회 완료")})
+    @GetMapping("/v1")
+    public ResponseEntity<?> findContentListV2(
             @ModelAttribute FindContentRequest request,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
@@ -71,9 +87,9 @@ public class ContentController {
                 HttpStatus.OK);
     }
 
-    @ApiOperation(value = "컨텐츠 상세정보 API v2")
+    @ApiOperation(value = "컨텐츠 상세정보 API v1")
     @ApiResponses({@ApiResponse(code = 200, message = "상세정보 조회 완료")})
-    @GetMapping("/v2/{contentId}")
+    @GetMapping("/v1/{contentId}")
     public ResponseEntity<?> findContentV2(@PathVariable Long contentId) {
 
         return new ResponseEntity<>(

--- a/src/main/java/com/linklip/linklipserver/controller/ContentController.java
+++ b/src/main/java/com/linklip/linklipserver/controller/ContentController.java
@@ -71,6 +71,20 @@ public class ContentController {
                 HttpStatus.OK);
     }
 
+    @ApiOperation(value = "컨텐츠 상세정보 API v2")
+    @ApiResponses({@ApiResponse(code = 200, message = "상세정보 조회 완료")})
+    @GetMapping("/v2/{contentId}")
+    public ResponseEntity<?> findContentV2(@PathVariable Long contentId) {
+
+        return new ResponseEntity<>(
+                new ServerResponseWithData(
+                        FIND_CONTENT_SUCCESS.getStatus(),
+                        FIND_CONTENT_SUCCESS.getSuccess(),
+                        FIND_CONTENT_SUCCESS.getMessage(),
+                        new FindContentResponse(contentService.findContent(contentId))),
+                HttpStatus.OK);
+    }
+
     @ApiOperation("링크 내용 수정 API v1")
     @ApiResponses({@ApiResponse(code = 200, message = "링크 내용 수정 완료")})
     @PatchMapping("/v1/link/{contentId}")

--- a/src/main/java/com/linklip/linklipserver/dto/content/ContentDto.java
+++ b/src/main/java/com/linklip/linklipserver/dto/content/ContentDto.java
@@ -1,7 +1,9 @@
 package com.linklip.linklipserver.dto.content;
 
 import com.linklip.linklipserver.dto.category.CategoryDto;
+import lombok.Getter;
 
+@Getter
 public class ContentDto {
 
     public String type;

--- a/src/main/java/com/linklip/linklipserver/dto/content/ContentDto.java
+++ b/src/main/java/com/linklip/linklipserver/dto/content/ContentDto.java
@@ -1,0 +1,11 @@
+package com.linklip.linklipserver.dto.content;
+
+import com.linklip.linklipserver.dto.category.CategoryDto;
+
+public class ContentDto {
+
+    public String type;
+    public Long id;
+    public CategoryDto category;
+
+}

--- a/src/main/java/com/linklip/linklipserver/dto/content/ContentDto.java
+++ b/src/main/java/com/linklip/linklipserver/dto/content/ContentDto.java
@@ -7,5 +7,4 @@ public class ContentDto {
     public String type;
     public Long id;
     public CategoryDto category;
-
 }

--- a/src/main/java/com/linklip/linklipserver/dto/content/LinkDto.java
+++ b/src/main/java/com/linklip/linklipserver/dto/content/LinkDto.java
@@ -5,14 +5,11 @@ import com.linklip.linklipserver.dto.category.CategoryDto;
 import lombok.Getter;
 
 @Getter
-public class LinkDto {
+public class LinkDto extends ContentDto {
 
-    private final Long id;
-    private final String type;
     private final String url;
     private final String linkImg;
     private final String title;
-    private CategoryDto category = null;
 
     public LinkDto(Link content) {
         this.id = content.getId();
@@ -23,12 +20,5 @@ public class LinkDto {
         if (content.getCategory() != null) {
             this.category = new CategoryDto(content.getCategory());
         }
-    }
-
-    public CategoryDto getCategory() {
-        if (category != null) {
-            return new CategoryDto(category);
-        }
-        return null;
     }
 }

--- a/src/main/java/com/linklip/linklipserver/dto/content/NoteDto.java
+++ b/src/main/java/com/linklip/linklipserver/dto/content/NoteDto.java
@@ -1,0 +1,19 @@
+package com.linklip.linklipserver.dto.content;
+
+import com.linklip.linklipserver.domain.Note;
+import com.linklip.linklipserver.dto.category.CategoryDto;
+import lombok.Getter;
+
+@Getter
+public class NoteDto extends ContentDto {
+    private final String text;
+
+    public NoteDto(Note content) {
+        this.id = content.getId();
+        this.type = content.getType();
+        this.text = content.getText();
+        if (content.getCategory() != null) {
+            this.category = new CategoryDto(content.getCategory());
+        }
+    }
+}

--- a/src/main/java/com/linklip/linklipserver/repository/ContentRepository.java
+++ b/src/main/java/com/linklip/linklipserver/repository/ContentRepository.java
@@ -15,18 +15,19 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     Page<Content> findAll(Pageable pageable);
 
     @EntityGraph(attributePaths = {"category"})
-    @Query(
-            "SELECT l FROM Link l WHERE l.category.id=:categoryId AND (l.title LIKE %:term% OR l.text LIKE %:term%)")
-    Page<Content> findByCategoryAndTerm(
-            @Param("categoryId") Long categoryId, @Param("term") String term, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"category"})
     @Query("SELECT c FROM Content c WHERE c.category.id=:categoryId")
     Page<Content> findByCategory(@Param("categoryId") Long categoryId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"category"})
-    @Query("SELECT l FROM Link l WHERE l.title LIKE %:term% OR l.text LIKE %:term%")
+    @Query(
+            "SELECT c FROM Content c WHERE treat(c as Link).linkUrl LIKE %:term% OR treat(c as Link).title LIKE %:term% OR treat(c as Link).text LIKE %:term% OR treat(c as Note).text LIKE %:term%")
     Page<Content> findByTerm(@Param("term") String term, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"category"})
+    @Query(
+            "SELECT c FROM Content c WHERE c.category.id=:categoryId AND (treat(c as Link).linkUrl LIKE %:term% OR treat(c as Link).title LIKE %:term% OR treat(c as Link).text LIKE %:term% OR treat(c as Note).text LIKE %:term%)")
+    Page<Content> findByCategoryAndTerm(
+            @Param("categoryId") Long categoryId, @Param("term") String term, Pageable pageable);
 
     @Modifying(clearAutomatically = true) // executeUpdate 같은 Annotation
     @Query("UPDATE Content c SET c.category = null WHERE c.category.id = :categoryId")

--- a/src/main/java/com/linklip/linklipserver/service/CategoryService.java
+++ b/src/main/java/com/linklip/linklipserver/service/CategoryService.java
@@ -1,5 +1,7 @@
 package com.linklip.linklipserver.service;
 
+import static com.linklip.linklipserver.constant.ErrorResponse.NOT_EXSIT_CATEGORY_ID;
+
 import com.linklip.linklipserver.domain.Category;
 import com.linklip.linklipserver.dto.category.CategoryDto;
 import com.linklip.linklipserver.dto.category.CreateCategoryRequest;
@@ -13,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.linklip.linklipserver.constant.ErrorResponse.NOT_EXSIT_CATEGORY_ID;
 
 @Service
 @Transactional(readOnly = true)
@@ -41,7 +41,10 @@ public class CategoryService {
         Category category =
                 categoryRepository
                         .findById(categoryId)
-                        .orElseThrow(() -> new IllegalArgumentException(NOT_EXSIT_CATEGORY_ID.getMessage()));
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                NOT_EXSIT_CATEGORY_ID.getMessage()));
         category.update(request.getName());
     }
 

--- a/src/main/java/com/linklip/linklipserver/service/CategoryService.java
+++ b/src/main/java/com/linklip/linklipserver/service/CategoryService.java
@@ -14,6 +14,8 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.linklip.linklipserver.constant.ErrorResponse.NOT_EXSIT_CATEGORY_ID;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -39,7 +41,7 @@ public class CategoryService {
         Category category =
                 categoryRepository
                         .findById(categoryId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 categoryId입니다."));
+                        .orElseThrow(() -> new IllegalArgumentException(NOT_EXSIT_CATEGORY_ID.getMessage()));
         category.update(request.getName());
     }
 
@@ -49,7 +51,7 @@ public class CategoryService {
         try {
             categoryRepository.deleteById(categoryId);
         } catch (EmptyResultDataAccessException e) {
-            throw new InvalidIdException("존재하지 않는 categoryId입니다.");
+            throw new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage());
         }
     }
 }

--- a/src/main/java/com/linklip/linklipserver/service/ContentService.java
+++ b/src/main/java/com/linklip/linklipserver/service/ContentService.java
@@ -47,7 +47,7 @@ public class ContentService {
         contentRepository.save(content);
     }
 
-    public Page<?> findContentList(FindContentRequest request, Pageable pageable) {
+    public Page<ContentDto> findContentList(FindContentRequest request, Pageable pageable) {
 
         String term = request.getTerm();
         Long categoryId = request.getCategoryId();
@@ -72,10 +72,15 @@ public class ContentService {
 
         return page.map(
                 (c) -> {
+                    // Link Content
                     if (c instanceof Link) {
                         return new LinkDto((Link) c);
                     }
-                    // TODO 수정 필요
+                    // Note Content
+                    if (c instanceof Note) {
+                        return new NoteDto((Note) c);
+                    }
+
                     return null;
                 });
     }
@@ -95,7 +100,7 @@ public class ContentService {
             return new NoteDto((Note) content);
         }
 
-        throw new InvalidIdException("존재하지 않는 contentId입니다");
+        throw new InvalidIdException("존재하지 않는 Content Type입니다");
     }
 
     @Transactional

--- a/src/main/java/com/linklip/linklipserver/service/ContentService.java
+++ b/src/main/java/com/linklip/linklipserver/service/ContentService.java
@@ -80,7 +80,7 @@ public class ContentService {
                 });
     }
 
-    public LinkDto findContent(Long contentId) {
+    public ContentDto findContent(Long contentId) {
 
         Content content =
                 contentRepository
@@ -91,8 +91,12 @@ public class ContentService {
             return new LinkDto((Link) content);
         }
 
-        // TODO 수정 필요
-        return null;
+        if (content instanceof Note) {
+            return new NoteDto((Note) content);
+        }
+
+        throw new InvalidIdException("존재하지 않는 contentId입니다");
+
     }
 
     @Transactional

--- a/src/main/java/com/linklip/linklipserver/service/ContentService.java
+++ b/src/main/java/com/linklip/linklipserver/service/ContentService.java
@@ -96,7 +96,6 @@ public class ContentService {
         }
 
         throw new InvalidIdException("존재하지 않는 contentId입니다");
-
     }
 
     @Transactional

--- a/src/main/java/com/linklip/linklipserver/service/ContentService.java
+++ b/src/main/java/com/linklip/linklipserver/service/ContentService.java
@@ -1,5 +1,7 @@
 package com.linklip.linklipserver.service;
 
+import static com.linklip.linklipserver.constant.ErrorResponse.*;
+
 import com.linklip.linklipserver.domain.Category;
 import com.linklip.linklipserver.domain.Content;
 import com.linklip.linklipserver.domain.Link;
@@ -15,8 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-
-import static com.linklip.linklipserver.constant.ErrorResponse.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -37,7 +37,10 @@ public class ContentService {
                         ? null
                         : categoryRepository
                                 .findById(categoryId)
-                                .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage()));
+                                .orElseThrow(
+                                        () ->
+                                                new InvalidIdException(
+                                                        NOT_EXSIT_CATEGORY_ID.getMessage()));
 
         Content content =
                 Link.builder()
@@ -93,7 +96,8 @@ public class ContentService {
         Content content =
                 contentRepository
                         .findById(contentId)
-                        .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
+                        .orElseThrow(
+                                () -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
 
         if (content instanceof Link) {
             return new LinkDto((Link) content);
@@ -112,7 +116,8 @@ public class ContentService {
         Content content =
                 contentRepository
                         .findById(id)
-                        .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
+                        .orElseThrow(
+                                () -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
 
         String title = request.getTitle();
         Long categoryId = request.getCategoryId();
@@ -121,7 +126,10 @@ public class ContentService {
                         ? null
                         : categoryRepository
                                 .findById(categoryId)
-                                .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage()));
+                                .orElseThrow(
+                                        () ->
+                                                new InvalidIdException(
+                                                        NOT_EXSIT_CATEGORY_ID.getMessage()));
         ((Link) content).update(title, category);
     }
 
@@ -131,7 +139,8 @@ public class ContentService {
         Content content =
                 contentRepository
                         .findById(contentId)
-                        .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
+                        .orElseThrow(
+                                () -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
         content.delete();
     }
 
@@ -144,7 +153,10 @@ public class ContentService {
                         ? null
                         : categoryRepository
                                 .findById(categoryId)
-                                .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage()));
+                                .orElseThrow(
+                                        () ->
+                                                new InvalidIdException(
+                                                        NOT_EXSIT_CATEGORY_ID.getMessage()));
 
         Content content = Note.builder().text(request.getText()).category(category).build();
         contentRepository.save(content);
@@ -156,7 +168,8 @@ public class ContentService {
         Content content =
                 contentRepository
                         .findById(contentId)
-                        .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
+                        .orElseThrow(
+                                () -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
 
         String text = request.getText();
         Long categoryId = request.getCategoryId();
@@ -165,7 +178,10 @@ public class ContentService {
                         ? null
                         : categoryRepository
                                 .findById(categoryId)
-                                .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage()));
+                                .orElseThrow(
+                                        () ->
+                                                new InvalidIdException(
+                                                        NOT_EXSIT_CATEGORY_ID.getMessage()));
         ((Note) content).update(text, category);
     }
 }

--- a/src/main/java/com/linklip/linklipserver/service/ContentService.java
+++ b/src/main/java/com/linklip/linklipserver/service/ContentService.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import static com.linklip.linklipserver.constant.ErrorResponse.*;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -35,7 +37,7 @@ public class ContentService {
                         ? null
                         : categoryRepository
                                 .findById(categoryId)
-                                .orElseThrow(() -> new InvalidIdException("존재하지 않는 categoryId입니다"));
+                                .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage()));
 
         Content content =
                 Link.builder()
@@ -82,7 +84,7 @@ public class ContentService {
                         return new NoteDto((Note) c);
                     }
 
-                    return null;
+                    throw new InvalidIdException(INVALID_CONTENT_TYPE.getMessage());
                 });
     }
 
@@ -91,7 +93,7 @@ public class ContentService {
         Content content =
                 contentRepository
                         .findById(contentId)
-                        .orElseThrow(() -> new InvalidIdException("존재하지 않는 contentId입니다"));
+                        .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
 
         if (content instanceof Link) {
             return new LinkDto((Link) content);
@@ -101,7 +103,7 @@ public class ContentService {
             return new NoteDto((Note) content);
         }
 
-        throw new InvalidIdException("존재하지 않는 Content Type입니다");
+        throw new InvalidIdException(INVALID_CONTENT_TYPE.getMessage());
     }
 
     @Transactional
@@ -110,7 +112,7 @@ public class ContentService {
         Content content =
                 contentRepository
                         .findById(id)
-                        .orElseThrow(() -> new InvalidIdException("존재하지 않는 contentId입니다"));
+                        .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
 
         String title = request.getTitle();
         Long categoryId = request.getCategoryId();
@@ -119,7 +121,7 @@ public class ContentService {
                         ? null
                         : categoryRepository
                                 .findById(categoryId)
-                                .orElseThrow(() -> new InvalidIdException("존재하지 않는 categoryId입니다"));
+                                .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage()));
         ((Link) content).update(title, category);
     }
 
@@ -129,7 +131,7 @@ public class ContentService {
         Content content =
                 contentRepository
                         .findById(contentId)
-                        .orElseThrow(() -> new InvalidIdException("존재하지 않는 contentId입니다"));
+                        .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
         content.delete();
     }
 
@@ -142,7 +144,7 @@ public class ContentService {
                         ? null
                         : categoryRepository
                                 .findById(categoryId)
-                                .orElseThrow(() -> new InvalidIdException("존재하지 않는 categoryId입니다"));
+                                .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage()));
 
         Content content = Note.builder().text(request.getText()).category(category).build();
         contentRepository.save(content);
@@ -154,7 +156,7 @@ public class ContentService {
         Content content =
                 contentRepository
                         .findById(contentId)
-                        .orElseThrow(() -> new InvalidIdException("존재하지 않는 contentId입니다"));
+                        .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CONTENT_ID.getMessage()));
 
         String text = request.getText();
         Long categoryId = request.getCategoryId();
@@ -163,7 +165,7 @@ public class ContentService {
                         ? null
                         : categoryRepository
                                 .findById(categoryId)
-                                .orElseThrow(() -> new InvalidIdException("존재하지 않는 categoryId입니다"));
+                                .orElseThrow(() -> new InvalidIdException(NOT_EXSIT_CATEGORY_ID.getMessage()));
         ((Note) content).update(text, category);
     }
 }

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
@@ -40,7 +40,7 @@ public class CategoryIntegrationTest {
 
     @Nested
     @DisplayName("카테고리 생성 통합테스트")
-    class createCategoryIntegrationTest {
+    class CreateCategoryIntegrationTest {
         @Test
         @DisplayName("일반적인 카테고리 명인 경우 201")
         public void createNormalCategory() throws Exception {
@@ -98,7 +98,7 @@ public class CategoryIntegrationTest {
 
     @Nested
     @DisplayName("카테고리 조회 통합테스트")
-    class findCategoryIntegrationTest {
+    class FindCategoryIntegrationTest {
         @Test
         @DisplayName("카테고리 조회에 성공한 경우 200")
         public void findCategory() throws Exception {
@@ -109,7 +109,7 @@ public class CategoryIntegrationTest {
 
     @Nested
     @DisplayName("카테고리 수정 통합테스트")
-    class updateCategoryIntegrationTest {
+    class UpdateCategoryIntegrationTest {
         @Test
         @DisplayName("일반적인 카테고리명 수정")
         public void updateCategory() throws Exception {
@@ -184,7 +184,7 @@ public class CategoryIntegrationTest {
 
     @Nested
     @DisplayName("카테고리 삭제 통합테스트")
-    class deleteCategoryIntegrationTest {
+    class DeleteCategoryIntegrationTest {
         @Test
         @DisplayName("컨텐츠가 존재하지 않는 카테고리 수정")
         public void deleteEmptyCategory() throws Exception {

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
@@ -116,8 +116,7 @@ public class CategoryIntegrationTest {
 
             // given
             Category category = testUtils.saveCategory("운동");
-            Category entity = categoryRepository.save(category);
-            long categoryId = entity.getId();
+            long categoryId = category.getId();
 
             // when
             UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest();
@@ -139,10 +138,8 @@ public class CategoryIntegrationTest {
 
             // given
             Category category1 = testUtils.saveCategory("운동");
-            Category entity = categoryRepository.save(category1);
-            Category category2 = testUtils.saveCategory("스포츠");
-            categoryRepository.save(category2);
-            long categoryId = entity.getId();
+            testUtils.saveCategory("스포츠");
+            long categoryId = category1.getId();
 
             // when
             UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest();
@@ -164,8 +161,7 @@ public class CategoryIntegrationTest {
 
             // given
             Category category = testUtils.saveCategory("운동");
-            Category entity = categoryRepository.save(category);
-            long categoryId = entity.getId();
+            long categoryId = category.getId();
 
             // when
             UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest();
@@ -190,14 +186,12 @@ public class CategoryIntegrationTest {
         public void deleteEmptyCategory() throws Exception {
             // given
             Category category1 = testUtils.saveCategory("운동");
-            Category category2 = testUtils.saveCategory("개발");
-            Category savedCategory1 = categoryRepository.save(category1);
-            categoryRepository.save(category2);
+            testUtils.saveCategory("개발");
 
             // when
             ResultActions actions =
                     mockMvc.perform(
-                            delete("/category/v1/{categoryId}", savedCategory1.getId())
+                            delete("/category/v1/{categoryId}", category1.getId())
                                     .contentType(MediaType.APPLICATION_JSON));
 
             // then
@@ -212,21 +206,16 @@ public class CategoryIntegrationTest {
         public void deleteCategoryHavingContents() throws Exception {
             // given
             Category category1 = testUtils.saveCategory("홈페이지");
-            Category savedCategory1 = categoryRepository.save(category1);
             Category category2 = testUtils.saveCategory("개발");
-            Category savedCategory2 = categoryRepository.save(category2);
 
-            Content content1 =
-                    testUtils.saveLink("naver.com", "Naver", "뉴스 로그인 회원가입", savedCategory1);
-            Content content2 =
-                    testUtils.saveLink("soma.org", "소프트웨어 마에스트로", "소마 홈페이지", savedCategory1);
-            Content content3 =
-                    testUtils.saveLink("soma.org", "소프트웨어 마에스트로", "소마 홈페이지", savedCategory2);
+            Content content1 = testUtils.saveLink("naver.com", "Naver", "뉴스 로그인 회원가입", category1);
+            Content content2 = testUtils.saveLink("soma.org", "소프트웨어 마에스트로", "소마 홈페이지", category1);
+            Content content3 = testUtils.saveLink("soma.org", "소프트웨어 마에스트로", "소마 홈페이지", category2);
 
             // when
             ResultActions actions =
                     mockMvc.perform(
-                            delete("/category/v1/{categoryId}", savedCategory1.getId())
+                            delete("/category/v1/{categoryId}", category1.getId())
                                     .contentType(MediaType.APPLICATION_JSON));
 
             // then
@@ -241,7 +230,7 @@ public class CategoryIntegrationTest {
 
             assertThat(findContent1.get().getCategory()).isEqualTo(null);
             assertThat(findContent2.get().getCategory()).isEqualTo(null);
-            assertThat(findContent3.get().getCategory().getId()).isEqualTo(savedCategory2.getId());
+            assertThat(findContent3.get().getCategory().getId()).isEqualTo(category2.getId());
         }
     }
 }

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
@@ -115,7 +115,8 @@ public class CategoryIntegrationTest {
         public void updateCategory() throws Exception {
 
             // given
-            Category category = Category.builder().name("운동").build();
+            Category category = testUtils.saveCategory("운동");
+            ;
             Category entity = categoryRepository.save(category);
             long categoryId = entity.getId();
 
@@ -138,9 +139,9 @@ public class CategoryIntegrationTest {
         public void updateCategoryByPresentName() throws Exception {
 
             // given
-            Category category1 = Category.builder().name("운동").build();
+            Category category1 = testUtils.saveCategory("운동");
             Category entity = categoryRepository.save(category1);
-            Category category2 = Category.builder().name("스포츠").build();
+            Category category2 = testUtils.saveCategory("스포츠");
             categoryRepository.save(category2);
             long categoryId = entity.getId();
 
@@ -163,7 +164,7 @@ public class CategoryIntegrationTest {
         public void updateCategoryByNullName() throws Exception {
 
             // given
-            Category category = Category.builder().name("운동").build();
+            Category category = testUtils.saveCategory("운동");
             Category entity = categoryRepository.save(category);
             long categoryId = entity.getId();
 
@@ -189,8 +190,8 @@ public class CategoryIntegrationTest {
         @DisplayName("컨텐츠가 존재하지 않는 카테고리 수정")
         public void deleteEmptyCategory() throws Exception {
             // given
-            Category category1 = Category.builder().name("운동").build();
-            Category category2 = Category.builder().name("개발").build();
+            Category category1 = testUtils.saveCategory("운동");
+            Category category2 = testUtils.saveCategory("개발");
             Category savedCategory1 = categoryRepository.save(category1);
             categoryRepository.save(category2);
 
@@ -211,9 +212,9 @@ public class CategoryIntegrationTest {
         @DisplayName("컨텐츠가 존재하는 카테고리 수정")
         public void deleteCategoryHavingContents() throws Exception {
             // given
-            Category category1 = Category.builder().name("홈페이지").build();
+            Category category1 = testUtils.saveCategory("홈페이지");
             Category savedCategory1 = categoryRepository.save(category1);
-            Category category2 = Category.builder().name("개발").build();
+            Category category2 = testUtils.saveCategory("개발");
             Category savedCategory2 = categoryRepository.save(category2);
 
             Content content1 =

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/CategoryIntegrationTest.java
@@ -116,7 +116,6 @@ public class CategoryIntegrationTest {
 
             // given
             Category category = testUtils.saveCategory("운동");
-            ;
             Category entity = categoryRepository.save(category);
             long categoryId = entity.getId();
 

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -298,7 +298,6 @@ public class ContentIntegrationTest {
         public void updateTitle() throws Exception {
 
             Category category = testUtils.saveCategory("활동");
-            ;
             categoryRepository.save(category);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
@@ -325,11 +324,9 @@ public class ContentIntegrationTest {
         public void updateTitleAndCategory() throws Exception {
 
             Category category1 = testUtils.saveCategory("활동");
-            ;
             categoryRepository.save(category1);
 
             Category category2 = testUtils.saveCategory("대외 활동");
-            ;
             categoryRepository.save(category2);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
@@ -359,11 +356,9 @@ public class ContentIntegrationTest {
         public void updateWithoutTitle() throws Exception {
 
             Category category1 = testUtils.saveCategory("활동");
-            ;
             categoryRepository.save(category1);
 
             Category category2 = testUtils.saveCategory("대외 활동");
-            ;
             categoryRepository.save(category2);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
@@ -449,9 +444,7 @@ public class ContentIntegrationTest {
             String text5 = "모의면접 방향성 고민해보자!";
 
             category1 = testUtils.saveCategory("활동");
-            ;
             category2 = testUtils.saveCategory("프로젝트");
-            ;
             categoryRepository.save(category1);
             categoryRepository.save(category2);
 

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -593,6 +593,7 @@ public class ContentIntegrationTest {
         }
     }
 
+    @Nested
     @DisplayName("메모 수정 통합테스트")
     class UpdateNoteContent {
 

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -52,8 +52,8 @@ public class ContentIntegrationTest {
             String url2 = "https://www.naver.com";
             String title = "소마";
 
-            category1 = Category.builder().name("활동").build();
-            Category category2 = Category.builder().name("스펙").build();
+            category1 = testUtils.saveCategory("활동");
+            Category category2 = testUtils.saveCategory("스펙");
             categoryRepository.save(category1);
             categoryRepository.save(category2);
 
@@ -243,7 +243,6 @@ public class ContentIntegrationTest {
     class FindLink {
 
         Content link1;
-        Content note1;
 
         @BeforeEach
         public void createContents() {
@@ -252,8 +251,8 @@ public class ContentIntegrationTest {
             String url2 = "https://www.naver.com";
             String title = "소마";
 
-            Category category1 = Category.builder().name("활동").build();
-            Category category2 = Category.builder().name("스펙").build();
+            Category category1 = testUtils.saveCategory("활동");
+            Category category2 = testUtils.saveCategory("스펙");
             categoryRepository.save(category1);
             categoryRepository.save(category2);
 
@@ -261,9 +260,6 @@ public class ContentIntegrationTest {
             testUtils.saveLink(url1, null, "소프트웨어 마에스트로 12기 연수생 여러분...", category1);
             testUtils.saveLink(url1, null, null, category2);
             testUtils.saveLink(url2, null, null, null);
-
-            // Note
-            note1 = testUtils.saveNote("아무 메모나 끄적끄적", category1);
         }
 
         @Test
@@ -291,32 +287,6 @@ public class ContentIntegrationTest {
             // then
             actions.andExpect(status().isBadRequest());
         }
-
-        @Test
-        @DisplayName("Note Content 상세보기")
-        public void finNoteContent() throws Exception {
-
-            // when
-            Long contentId = note1.getId();
-            ResultActions actions = mockMvc.perform(get("/content/v1/{contentId}", contentId));
-
-            // then
-            actions.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.content.id").value(contentId))
-                    .andExpect(jsonPath("$.data.content.text").value(((Note) note1).getText()));
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 id  Note Content 상세보기")
-        public void findNotExistNoteContent() throws Exception {
-
-            // when
-            Long contentId = 987654321L;
-            ResultActions actions = mockMvc.perform(get("/content/v1/{contentId}", contentId));
-
-            // then
-            actions.andExpect(status().isBadRequest());
-        }
     }
 
     @Nested
@@ -327,7 +297,8 @@ public class ContentIntegrationTest {
         @DisplayName("링크 컨텐츠의 Title만 수정")
         public void updateTitle() throws Exception {
 
-            Category category = Category.builder().name("활동").build();
+            Category category = testUtils.saveCategory("활동");
+            ;
             categoryRepository.save(category);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
@@ -353,10 +324,12 @@ public class ContentIntegrationTest {
         @DisplayName("링크 컨텐츠의 Title과 카테고리 수정")
         public void updateTitleAndCategory() throws Exception {
 
-            Category category1 = Category.builder().name("활동").build();
+            Category category1 = testUtils.saveCategory("활동");
+            ;
             categoryRepository.save(category1);
 
-            Category category2 = Category.builder().name("대외 활동").build();
+            Category category2 = testUtils.saveCategory("대외 활동");
+            ;
             categoryRepository.save(category2);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
@@ -385,10 +358,12 @@ public class ContentIntegrationTest {
         @DisplayName("링크 컨텐츠의 Title 없이 수정 요청을 보내면 400")
         public void updateWithoutTitle() throws Exception {
 
-            Category category1 = Category.builder().name("활동").build();
+            Category category1 = testUtils.saveCategory("활동");
+            ;
             categoryRepository.save(category1);
 
-            Category category2 = Category.builder().name("대외 활동").build();
+            Category category2 = testUtils.saveCategory("대외 활동");
+            ;
             categoryRepository.save(category2);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
@@ -473,8 +448,10 @@ public class ContentIntegrationTest {
             String text4 = "다음주 멘토링은 목요일에 온라인으로";
             String text5 = "모의면접 방향성 고민해보자!";
 
-            category1 = Category.builder().name("활동").build();
-            category2 = Category.builder().name("프로젝트").build();
+            category1 = testUtils.saveCategory("활동");
+            ;
+            category2 = testUtils.saveCategory("프로젝트");
+            ;
             categoryRepository.save(category1);
             categoryRepository.save(category2);
 
@@ -590,6 +567,44 @@ public class ContentIntegrationTest {
             actions.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.content.id").value(contentId))
                     .andExpect(jsonPath("$.data.content.text").value(((Note) note1).getText()));
+        }
+    }
+
+    @Nested
+    @DisplayName("메모 상세보기 통합테스트")
+    class FindNote {
+
+        Content note1;
+
+        @BeforeEach
+        public void createContents() {
+            note1 = testUtils.saveNote("테스트 메모 1", null);
+        }
+
+        @Test
+        @DisplayName("Note Content 상세보기")
+        public void finNoteContent() throws Exception {
+
+            // when
+            Long contentId = note1.getId();
+            ResultActions actions = mockMvc.perform(get("/content/v1/{contentId}", contentId));
+
+            // then
+            actions.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content.id").value(contentId))
+                    .andExpect(jsonPath("$.data.content.text").value(((Note) note1).getText()));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 id의 Note Content 상세보기")
+        public void findNotExistNoteContent() throws Exception {
+
+            // when
+            Long contentId = 987654321L;
+            ResultActions actions = mockMvc.perform(get("/content/v1/{contentId}", contentId));
+
+            // then
+            actions.andExpect(status().isBadRequest());
         }
     }
 

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -74,7 +74,7 @@ public class ContentIntegrationTest {
                 Long categoryId = category1.getId();
                 ResultActions actions =
                         mockMvc.perform(
-                                get("/content/v1/link")
+                                get("/content/v1")
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .param("categoryId", String.valueOf(categoryId))
                                         .param("page", "0")
@@ -94,7 +94,7 @@ public class ContentIntegrationTest {
                 String term = "소마";
                 ResultActions actions =
                         mockMvc.perform(
-                                get("/content/v1/link")
+                                get("/content/v1 ")
                                         .param("categoryId", String.valueOf(categoryId))
                                         .param("term", term)
                                         .param("page", "0")
@@ -114,7 +114,7 @@ public class ContentIntegrationTest {
                 String term = "";
                 ResultActions actions =
                         mockMvc.perform(
-                                get("/content/v1/link")
+                                get("/content/v1")
                                         .param("categoryId", String.valueOf(categoryId))
                                         .param("term", term)
                                         .param("page", "0")
@@ -134,7 +134,7 @@ public class ContentIntegrationTest {
                 String term = "1기";
                 ResultActions actions =
                         mockMvc.perform(
-                                get("/content/v1/link")
+                                get("/content/v1")
                                         .param("categoryId", String.valueOf(categoryId))
                                         .param("term", term)
                                         .param("page", "0")
@@ -158,7 +158,7 @@ public class ContentIntegrationTest {
                 String term = "소마";
                 ResultActions actions =
                         mockMvc.perform(
-                                get("/content/v1/link")
+                                get("/content/v1")
                                         .param("term", term)
                                         .param("page", "0")
                                         .param("size", "20"));
@@ -176,7 +176,7 @@ public class ContentIntegrationTest {
                 String term = "";
                 ResultActions actions =
                         mockMvc.perform(
-                                get("/content/v1/link")
+                                get("/content/v1")
                                         .param("term", term)
                                         .param("page", "0")
                                         .param("size", "20"));
@@ -194,7 +194,7 @@ public class ContentIntegrationTest {
                 String term = "1기";
                 ResultActions actions =
                         mockMvc.perform(
-                                get("/content/v1/link")
+                                get("/content/v1")
                                         .param("term", term)
                                         .param("page", "0")
                                         .param("size", "20"));
@@ -210,8 +210,7 @@ public class ContentIntegrationTest {
 
                 // when
                 ResultActions actions =
-                        mockMvc.perform(
-                                get("/content/v1/link").param("page", "0").param("size", "20"));
+                        mockMvc.perform(get("/content/v1").param("page", "0").param("size", "20"));
 
                 // then
                 actions.andExpect(status().isOk())
@@ -230,7 +229,7 @@ public class ContentIntegrationTest {
 
             // when
             ResultActions actions =
-                    mockMvc.perform(get("/content/v1/link").param("page", "1").param("size", "3"));
+                    mockMvc.perform(get("/content/v1").param("page", "1").param("size", "3"));
 
             // then
             actions.andExpect(status().isOk())
@@ -272,7 +271,7 @@ public class ContentIntegrationTest {
 
             // when
             Long contentId = link1.getId();
-            ResultActions actions = mockMvc.perform(get("/content/v1/link/{contentId}", contentId));
+            ResultActions actions = mockMvc.perform(get("/content/v1/{contentId}", contentId));
 
             // then
             actions.andExpect(status().isOk())
@@ -286,7 +285,7 @@ public class ContentIntegrationTest {
             // when
             Long contentId = 987654321L;
             System.out.println(link1.getId());
-            ResultActions actions = mockMvc.perform(get("/content/v1/link/{contentId}", contentId));
+            ResultActions actions = mockMvc.perform(get("/content/v1/{contentId}", contentId));
 
             // then
             actions.andExpect(status().isBadRequest());
@@ -298,7 +297,7 @@ public class ContentIntegrationTest {
 
             // when
             Long contentId = note1.getId();
-            ResultActions actions = mockMvc.perform(get("/content/v2/{contentId}", contentId));
+            ResultActions actions = mockMvc.perform(get("/content/v1/{contentId}", contentId));
 
             // then
             actions.andExpect(status().isOk())
@@ -312,7 +311,7 @@ public class ContentIntegrationTest {
 
             // when
             Long contentId = 987654321L;
-            ResultActions actions = mockMvc.perform(get("/content/v2/{contentId}", contentId));
+            ResultActions actions = mockMvc.perform(get("/content/v1/{contentId}", contentId));
 
             // then
             actions.andExpect(status().isBadRequest());

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -10,6 +10,7 @@ import com.linklip.linklipserver.TestUtils;
 import com.linklip.linklipserver.domain.Category;
 import com.linklip.linklipserver.domain.Content;
 import com.linklip.linklipserver.domain.Link;
+import com.linklip.linklipserver.domain.Note;
 import com.linklip.linklipserver.dto.content.UpdateLinkRequest;
 import com.linklip.linklipserver.repository.CategoryRepository;
 import com.linklip.linklipserver.repository.ContentRepository;
@@ -241,10 +242,12 @@ public class ContentIntegrationTest {
     @DisplayName("링크 상세보기 통합테스트")
     class findContent {
 
-        Content content;
+        Content link1;
+        Content note1;
 
         @BeforeEach
         public void createContents() {
+            // Link
             String url1 = "https://www.swmaestro.org";
             String url2 = "https://www.naver.com";
             String title = "소마";
@@ -254,10 +257,14 @@ public class ContentIntegrationTest {
             categoryRepository.save(category1);
             categoryRepository.save(category2);
 
-            content = testUtils.saveLink(url1, title, "소프트웨어 마에스트로 12기 연수생 여러분...", category1);
+            link1 = testUtils.saveLink(url1, title, "소프트웨어 마에스트로 12기 연수생 여러분...", category1);
             testUtils.saveLink(url1, null, "소프트웨어 마에스트로 12기 연수생 여러분...", category1);
             testUtils.saveLink(url1, null, null, category2);
             testUtils.saveLink(url2, null, null, null);
+
+            // Note
+            note1 = testUtils.saveNote("아무 메모나 끄적끄적", category1);
+
         }
 
         @Test
@@ -265,7 +272,7 @@ public class ContentIntegrationTest {
         public void findNormalContent() throws Exception {
 
             // when
-            Long contentId = content.getId();
+            Long contentId = link1.getId();
             ResultActions actions = mockMvc.perform(get("/content/v1/link/{contentId}", contentId));
 
             // then
@@ -279,11 +286,25 @@ public class ContentIntegrationTest {
 
             // when
             Long contentId = 987654321L;
-            System.out.println(content.getId());
+            System.out.println(link1.getId());
             ResultActions actions = mockMvc.perform(get("/content/v1/link/{contentId}", contentId));
 
             // then
             actions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("Note Content 상세보기")
+        public void finNoteContent() throws Exception {
+
+            // when
+            Long contentId = note1.getId();
+            ResultActions actions = mockMvc.perform(get("/content/v2/{contentId}", contentId));
+
+            // then
+            actions.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content.id").value(contentId))
+                    .andExpect(jsonPath("$.data.content.text").value(((Note) note1).getText()));
         }
     }
 

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -54,8 +54,6 @@ public class ContentIntegrationTest {
 
             category1 = testUtils.saveCategory("활동");
             Category category2 = testUtils.saveCategory("스펙");
-            categoryRepository.save(category1);
-            categoryRepository.save(category2);
 
             testUtils.saveLink(url1, title, "소프트웨어 마에스트로 12기 연수생 여러분...", category1);
             testUtils.saveLink(url1, null, "소프트웨어 마에스트로 13기 연수생 여러분...", category1);
@@ -253,8 +251,6 @@ public class ContentIntegrationTest {
 
             Category category1 = testUtils.saveCategory("활동");
             Category category2 = testUtils.saveCategory("스펙");
-            categoryRepository.save(category1);
-            categoryRepository.save(category2);
 
             link1 = testUtils.saveLink(url1, title, "소프트웨어 마에스트로 12기 연수생 여러분...", category1);
             testUtils.saveLink(url1, null, "소프트웨어 마에스트로 12기 연수생 여러분...", category1);
@@ -298,7 +294,6 @@ public class ContentIntegrationTest {
         public void updateTitle() throws Exception {
 
             Category category = testUtils.saveCategory("활동");
-            categoryRepository.save(category);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
             Content savedContent =
@@ -324,10 +319,8 @@ public class ContentIntegrationTest {
         public void updateTitleAndCategory() throws Exception {
 
             Category category1 = testUtils.saveCategory("활동");
-            categoryRepository.save(category1);
 
             Category category2 = testUtils.saveCategory("대외 활동");
-            categoryRepository.save(category2);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
             Content savedContent =
@@ -356,10 +349,8 @@ public class ContentIntegrationTest {
         public void updateWithoutTitle() throws Exception {
 
             Category category1 = testUtils.saveCategory("활동");
-            categoryRepository.save(category1);
 
             Category category2 = testUtils.saveCategory("대외 활동");
-            categoryRepository.save(category2);
 
             String url = "https://www.swmaestro.org/sw/main/main.do";
             Content savedContent =
@@ -445,8 +436,6 @@ public class ContentIntegrationTest {
 
             category1 = testUtils.saveCategory("활동");
             category2 = testUtils.saveCategory("프로젝트");
-            categoryRepository.save(category1);
-            categoryRepository.save(category2);
 
             note1 = testUtils.saveNote(text1, category1);
             testUtils.saveNote(text2, category2);

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -42,7 +42,7 @@ public class ContentIntegrationTest {
 
     @Nested
     @DisplayName("링크 검색 통합테스트")
-    class findLinks {
+    class FindLinks {
 
         Category category1;
 
@@ -65,7 +65,7 @@ public class ContentIntegrationTest {
 
         @Nested
         @DisplayName("카테고리 해당 컨텐츠")
-        class findContentsByCategory {
+        class FindContentsByCategory {
 
             @DisplayName("컨텐츠 불러오기")
             @Test
@@ -88,7 +88,7 @@ public class ContentIntegrationTest {
 
             @DisplayName("일반적인 검색어")
             @Test
-            public void findContentByNormalTerm() throws Exception {
+            public void FindContentByNormalTerm() throws Exception {
 
                 // when
                 Long categoryId = category1.getId();
@@ -149,7 +149,7 @@ public class ContentIntegrationTest {
 
         @Nested
         @DisplayName("전체 검색어")
-        class findContentsByTerm {
+        class FindContentsByTerm {
 
             @DisplayName("일반적인 검색어")
             @Test
@@ -240,7 +240,7 @@ public class ContentIntegrationTest {
 
     @Nested
     @DisplayName("링크 상세보기 통합테스트")
-    class findLink {
+    class FindLink {
 
         Content link1;
         Content note1;
@@ -321,7 +321,7 @@ public class ContentIntegrationTest {
 
     @Nested
     @DisplayName("링크 수정 통합테스트")
-    class updateLink {
+    class UpdateLink {
 
         @Test
         @DisplayName("링크 컨텐츠의 Title만 수정")
@@ -411,7 +411,7 @@ public class ContentIntegrationTest {
 
     @Nested
     @DisplayName("컨텐츠 삭제")
-    class deleteContent {
+    class DeleteContent {
 
         @Test
         @DisplayName("일반적인 경우")

--- a/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
+++ b/src/test/java/com/linklip/linklipserver/IntegrationtTest/ContentIntegrationTest.java
@@ -264,7 +264,6 @@ public class ContentIntegrationTest {
 
             // Note
             note1 = testUtils.saveNote("아무 메모나 끄적끄적", category1);
-
         }
 
         @Test
@@ -305,6 +304,18 @@ public class ContentIntegrationTest {
             actions.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.content.id").value(contentId))
                     .andExpect(jsonPath("$.data.content.text").value(((Note) note1).getText()));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 id  Note Content 상세보기")
+        public void findNotExistNoteContent() throws Exception {
+
+            // when
+            Long contentId = 987654321L;
+            ResultActions actions = mockMvc.perform(get("/content/v2/{contentId}", contentId));
+
+            // then
+            actions.andExpect(status().isBadRequest());
         }
     }
 

--- a/src/test/java/com/linklip/linklipserver/TestUtils.java
+++ b/src/test/java/com/linklip/linklipserver/TestUtils.java
@@ -26,7 +26,7 @@ public class TestUtils {
     }
 
     public Content saveNote(String text, Category category) {
-        
+
         Content content = Note.builder().text(text).category(category).build();
         contentRepository.save(content);
 

--- a/src/test/java/com/linklip/linklipserver/TestUtils.java
+++ b/src/test/java/com/linklip/linklipserver/TestUtils.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linklip.linklipserver.domain.Category;
 import com.linklip.linklipserver.domain.Content;
 import com.linklip.linklipserver.domain.Link;
+import com.linklip.linklipserver.domain.Note;
 import com.linklip.linklipserver.repository.CategoryRepository;
 import com.linklip.linklipserver.repository.ContentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,13 @@ public class TestUtils {
 
         Content content =
                 Link.builder().linkUrl(url).title(title).text(text).category(category).build();
+        contentRepository.save(content);
+
+        return content;
+    }
+
+    public Content saveNote(String text, Category category) {
+        Content content = Note.builder().text(text).category(category).build();
         contentRepository.save(content);
 
         return content;

--- a/src/test/java/com/linklip/linklipserver/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/linklip/linklipserver/repository/CategoryRepositoryTest.java
@@ -20,7 +20,7 @@ class CategoryRepositoryTest {
 
     @Nested
     @DisplayName("카테고리 생성 테스트")
-    class saveCategory {
+    class SaveCategory {
 
         @Test
         @DisplayName("일반적인 카테고리 명 생성")
@@ -64,7 +64,7 @@ class CategoryRepositoryTest {
 
     @Nested
     @DisplayName("카테고리 조회 테스트")
-    class findCategory {
+    class FindCategory {
         @Test
         @DisplayName("이름 순으로 카테고리 조회")
         public void findCategoryNormal() {
@@ -82,7 +82,7 @@ class CategoryRepositoryTest {
 
     @Nested
     @DisplayName("카테고리 삭제 테스트")
-    class deleteCategory {
+    class DeleteCategory {
         @Test
         @DisplayName("일반적인 카테고리 삭제")
         public void deleteCategoryNormal() {

--- a/src/test/java/com/linklip/linklipserver/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/linklip/linklipserver/repository/CategoryRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.linklip.linklipserver.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.linklip.linklipserver.domain.Category;
 import java.util.List;

--- a/src/test/java/com/linklip/linklipserver/repository/ContentRepositoryTest.java
+++ b/src/test/java/com/linklip/linklipserver/repository/ContentRepositoryTest.java
@@ -26,7 +26,7 @@ class ContentRepositoryTest {
 
     @Nested
     @DisplayName("링크 저장 테스트")
-    class saveLink {
+    class SaveLink {
 
         @Test
         @DisplayName("링크 url만 저장")
@@ -88,7 +88,7 @@ class ContentRepositoryTest {
 
     @Nested
     @DisplayName("링크 검색 테스트")
-    class findContents {
+    class FindContents {
 
         PageRequest pageRequest = PageRequest.of(0, 3, Sort.by(Sort.Direction.DESC, "id"));
         Category category;
@@ -125,7 +125,7 @@ class ContentRepositoryTest {
 
         @Nested
         @DisplayName("카테고리 해당 컨텐츠")
-        class findContentsByCategory {
+        class FindContentsByCategory {
 
             @Test
             @DisplayName("컨텐츠 불러오기")
@@ -216,7 +216,7 @@ class ContentRepositoryTest {
 
         @Nested
         @DisplayName("전체 검색어")
-        class findContentsByTerm {
+        class FindContentsByTerm {
 
             @Test
             @DisplayName("일반적인 검색어")
@@ -352,7 +352,7 @@ class ContentRepositoryTest {
 
     @Nested
     @DisplayName("컨텐츠 상세보기")
-    class findContent {
+    class FindContent {
 
         @Test
         @DisplayName("일반적인 경우")
@@ -377,7 +377,7 @@ class ContentRepositoryTest {
 
     @Nested
     @DisplayName("메모 저장 테스트")
-    class saveNoteContent {
+    class SaveNoteContent {
 
         @Test
         @DisplayName("카테고리 설정 없이 메모 저장")


### PR DESCRIPTION
### ✅ Checklist

- [x] Set Reviewers

- [x] Set Labels

---

### 📕 Task

- [x] 메모 상세조회 API 구현
- [x] 메모 검색결과 조회 API 구현
- [x] 메모 조회 관련 통합테스트 작성
- [x] 테스트 Class 명 대문자로 시작하도록 수정


### 😳 Issue

- [ ] treat를 사용한 JPQL문이 너무 길어서, 개선안 함께 고민해 보면 좋을 것 같습니다!!
